### PR TITLE
#73 feat: 탈퇴한 유저 팀 정보 db에 반영

### DIFF
--- a/src/main/java/site/bbichul/service/UserService.java
+++ b/src/main/java/site/bbichul/service/UserService.java
@@ -84,6 +84,10 @@ public class UserService {
         User user = userRepository.findByUsername(username).orElseThrow(
                 () -> new NullPointerException("그럴리가 없쥬")
         );
+        if (user.getTeam() != null) {
+            user.setTeam(null);
+        }
+
         user.updateStatus(userDto);
     }
 


### PR DESCRIPTION
# 반영 브랜치
dev

# 변경 사항
탈퇴할 경우 팀에서도 해당 유저 조회할 수 없게 변경

# 확인 방법 (스크린샷 포함)
![image](https://user-images.githubusercontent.com/30096290/144554127-6321d979-ecd6-4889-a6a2-7f9bf1e9bebc.png)

탈퇴하기 전 유저 db

![image](https://user-images.githubusercontent.com/30096290/144554160-fb476f29-5977-41e2-9a69-5ecc71f98379.png)

탈퇴 후 team_id가 변경된 유저 db

resolved #73 